### PR TITLE
Fix 680244 - Links to FF9 instead of FF10

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -15,7 +15,7 @@ import jinja2
 
 
 # mod_autoindex generated HTML containing builds:
-APACHE_QUERY_STRING = '?C=M;O=D'
+APACHE_QUERY_STRING = '?C=M;O=A'
 
 CURRENT_PATH = os.path.dirname(__file__)
 


### PR DESCRIPTION
When multiple matching builds are present, the last one in Apache page order will override all others. So by changing the listing order from descendant to ascendant, we ensure that the latest build is offered.
