### PR TITLE
Change "Getting Started" Litmus link to refer to MozTrap

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -74,7 +74,7 @@
       <ul>
         <li><a href="https://input.mozilla.com/feedback">Submit your feedback</a></li>
         <li><a href="https://developer.mozilla.org/en/Crash_reporting">Submit crash reports</a></li>
-        <li><a href="https://litmus.mozilla.org/">Run test cases in Litmus</a></li>
+        <li><a href="https://moztrap.mozilla.org/">Run test cases in MozTrap</a></li>
         <li><a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox">Report bugs in Bugzilla</a></li>
       </ul>
     </section>


### PR DESCRIPTION
fix bug 773476
