### PR TITLE
Update the Android links to point to the multilocale apks (bug 791482)

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -88,7 +88,7 @@ files = [
                 'extension': 'apk',
                 'name': 'Android',
                 'suffix': '.multi.android-arm',
-                'url': 'latest-mozilla-central-android/en-US/',
+                'url': 'latest-mozilla-central-android/',
             },
             {
                 'class': 'android',


### PR DESCRIPTION
Add ".multi" to the suffix for both Android builds so the correct multilocale builds show up on nightly.mozilla.org.
