### PR TITLE
Kill the maemo mailing list & QAC addon links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,6 @@
 
       <ul>
         <li><a href="https://addons.mozilla.org/firefox/addon/nightly-tester-tools/">Nightly Tester Tools</a></li>
-        <li><a href="https://addons.mozilla.org/firefox/addon/mozilla-qa-companion/">QA Companion</a></li>
         <li><a href="https://addons.mozilla.org/firefox/addon/add-on-compatibility-reporter/">Add-on Compatibility Reporter</a></li>
         <li><a href="https://addons.mozilla.org/firefox/addon/mozmill/">MozMill</a></li>
       </ul>


### PR DESCRIPTION
There is no active maemo product nor any active QAC add-on anymore.
