### PR TITLE
Bug 853026 - nightly.mozilla.org should link to x86 android builds

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -103,6 +103,14 @@ files = [
                 'name': 'Android (ARMv6)',
                 'suffix': '.multi.android-arm-armv6',
                 'url': 'latest-mozilla-central-android-armv6/',
+            },
+            {
+                'class': 'android',
+                'extension': 'apk',
+                'name': 'Android (x86)',
+                'suffix': '.multi.android-i386',
+                'url': 'latest-mozilla-central-android-x86/'
+
             }
         ],
     },


### PR DESCRIPTION
This adds x86 builds for Android on the nightly page
