### PR TITLE
Shorten the One and Done link label

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,7 @@
       <ul>
         <li><a href="https://input.mozilla.com/feedback">Submit your feedback</a></li>
         <li><a href="https://developer.mozilla.org/en/Crash_reporting">Submit crash reports</a></li>
-        <li><a href="https://oneanddone.mozilla.org/">Find testing tasks in One and Done</a></li>
+        <li><a href="https://oneanddone.mozilla.org/">Find testing tasks</a></li>
         <li><a href="https://moztrap.mozilla.org/">Run test cases in MozTrap</a></li>
         <li><a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox">Report Firefox bugs in Bugzilla</a></li>
         <li><a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox%20for%20Android">Report Firefox for Android bugs</a></li>


### PR DESCRIPTION
As per @whimboo's [Comment 12 in Bug 852454](https://bugzilla.mozilla.org/show_bug.cgi?id=852454#c12).
