### PR TITLE
Fix #31, Change the link for Get Involved in the Mobile Section in the navbar for Bug #1108396.

### DIFF
--- a/templates/global/menu_links.html
+++ b/templates/global/menu_links.html
@@ -21,7 +21,7 @@
         <li><a href="https://addons.mozilla.org/mobile/?browse=featured">{{ _('Customize') }}</a></li>
         <li><a href="https://www.mozilla.org/mobile/sync/">{{ _('Sync') }}</a></li>
         <li><a href="https://developer.mozilla.org/mobile">{{ _('Develop') }}</a></li>
-        <li><a href="https://www.mozilla.org/mobile/getinvolved/">{{ _('Get Involved') }}</a></li>
+        <li><a href="https://wiki.mozilla.org/Mobile/Get_Involved">{{ _('Get Involved') }}</a></li>
         <li><a href="https://www.mozilla.org/mobile/faq/">{{ _('FAQ') }}</a></li>
         <li><a href="https://blog.mozilla.com/mobile/">{{ _('Blog') }}</a></li>
         <li><a href="https://www.mozilla.org/en-US/firefox/video?video=fx4-mobile-greatday">{{ _('Videos') }}</a></li>


### PR DESCRIPTION
I have changed the link to the **wiki** page for **Mobile/Get_Involved**.
