### PR TITLE
Fix date and size order in scraper

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -187,9 +187,9 @@ class URLLister(SGMLParser):
             return
 
         if (self.link):
-            if self.date == None:
+            if self.date is None and "-" in text:
                 self.date = text.split()[0]
-            elif self.size == None:
+            elif self.size is None:
                 self.size = text
 
     def handle_data(self, text):


### PR DESCRIPTION
The new format lister has size and then date, instead of date and then
size. Right now there are two formats in play, so this change attempts
to figure out the correct format.

https://bugzilla.mozilla.org/show_bug.cgi?id=1216816